### PR TITLE
Fix 4 CTS Media issues

### DIFF
--- a/src/egl/drivers/dri2/platform_android.c
+++ b/src/egl/drivers/dri2/platform_android.c
@@ -461,8 +461,11 @@ droid_create_surface(_EGLDriver *drv, _EGLDisplay *disp, EGLint type,
       }
 
       /* Clamp preferred between minimum (min undequeued + 1 dequeued)
-       * and maximum.
+       * and maximum. And we also need confirm min_buffer_count less
+       * than max_buffer_count
        */
+      if (min_buffer_count == max_buffer_count)
+         max_buffer_count++;
       buffer_count = CLAMP(preferred_buffer_count, min_buffer_count + 1,
                            max_buffer_count);
 


### PR DESCRIPTION
Sometimes, when min_buffer_count is equal to max_buffer_count(1),
the buffer count will still be 1. And we will not conside 1 more
dequeue buffer. This will cause "setBufferCount" error in framework.

Tests: Fix CTS Media issues android.media.cts.HeifWriterTest

Signed-off-by: Chenglei Ren <chenglei.ren@intel.com>
Tracked-On: OAM-91605