### PR TITLE
UPSTREAM: Fix CtsGwpAsanTestCases crash on x86_64

### DIFF
--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -349,4 +349,14 @@ enum pipe_debug_type
    PIPE_DEBUG_TYPE_CONFORMANCE,
 };
 
+#if !defined(alignof) && !defined(__cplusplus)
+#if __STDC_VERSION__ >= 201112L
+#define alignof(t) _Alignof(t)
+#elif defined(_MSC_VER)
+#define alignof(t) __alignof(t)
+#else
+#define alignof(t) __alignof__(t)
+#endif
+#endif
+
 #endif /* UTIL_MACROS_H */


### PR DESCRIPTION
This combines two upstream patches which could help fix
CtsGwpAsanTestCases crash on x86_64

391eeb744356353e96ce34f23b8b16b718a02d61
util: add a alignof() macro

Signed-off-by: Rhys Perry <pendingchaos02@gmail.com>
Reviewed-by: Eric Anholt <eric@anholt.net>

a4c708dd24e5ba8ac381973c14db8d23f4ac97bf
On some malloc implementation, malloc doesn't always align to 16
bytes even on 64 bits system. To make sure ralloc_header always
starts at the wanted alignment, just force the size to be aligned at
the alignment of ralloc_header. This fixes crashed on instruction
like "movaps %xmm0,0x10(%rax)" which requires aligned memory access.

Signed-off-by: Lepton Wu <lepton@chromium.org>
Reviewed-by: Marek Olšák <marek.olsak@amd.com>

Tracked-On: OAM-95765