### PR TITLE
Update PYTHONPATH to include Mako

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -42,7 +42,7 @@ MESA_DRI_MODULE_UNSTRIPPED_PATH := $(TARGET_OUT_SHARED_LIBRARIES_UNSTRIPPED)/$(M
 MESA_DRI_LDFLAGS := -Wl,--build-id=sha1
 
 MESA_COMMON_MK := $(MESA_TOP)/Android.common.mk
-MESA_PYTHON2 := python
+MESA_PYTHON2 := PYTHONPATH=$(PWD)/development/python-packages:$$PYTHONPATH python
 MESA_PYTHON3 := python3
 ifeq ($(filter 5 6 7 8 9 10, $(MESA_ANDROID_MAJOR_VERSION)),)
 MESA_LEX     := M4=$(M4) $(LEX)


### PR DESCRIPTION
This is required as part of enabling path
restrictions in Android 11

Tracked-On: OAM-95316
Signed-off-by: yaravapa <yasoda.aravapalli@intel.com>