### PR TITLE
W/A: Remove performance info query resulting in CFI kernel panic

### DIFF
--- a/src/gallium/drivers/iris/iris_screen.c
+++ b/src/gallium/drivers/iris/iris_screen.c
@@ -776,8 +776,5 @@ iris_screen_create(int fd, const struct pipe_screen_config *config)
    pscreen->flush_frontbuffer = iris_flush_frontbuffer;
    pscreen->get_timestamp = iris_get_timestamp;
    pscreen->query_memory_info = iris_query_memory_info;
-   pscreen->get_driver_query_group_info = iris_get_monitor_group_info;
-   pscreen->get_driver_query_info = iris_get_monitor_info;
-
    return pscreen;
 }


### PR DESCRIPTION
With get_driver_query_group_info and get_driver_query_info
set, call to kernel to get performance information results
in CFI kernel panic.

As its not must to provide performance information, remove
setting of get_driver_query_group_info and get_driver_query_info.

Tracked-On: OAM-96773
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>