### PR TITLE
INTERNEL: fix a deadlock during execute CTS cases

### DIFF
--- a/src/mesa/state_tracker/st_manager.c
+++ b/src/mesa/state_tracker/st_manager.c
@@ -1086,9 +1086,11 @@ st_api_make_current(struct st_api *stapi, struct st_context_iface *stctxi,
       }
 
       if (stdraw && stread) {
-         st_framebuffer_validate(stdraw, st);
-         if (stread != stdraw)
-            st_framebuffer_validate(stread, st);
+          if (st->ctx->FirstTimeCurrent) {
+             st_framebuffer_validate(stdraw, st);
+             if (stread != stdraw)
+                st_framebuffer_validate(stread, st);
+         }
 
          ret = _mesa_make_current(st->ctx, &stdraw->Base, &stread->Base);
 


### PR DESCRIPTION
This patch try to fix a deadlock issue when runing
android.media.cts.HeifWriterTest#testInputSurface_Grid_Handler
In this case, there are two deadlock threads involved, the HeifWriter
thread and a drawframe thread. The drawframe thread will try to draw a
frame and send it to HeifWriter. By calling st_api_make_currentst() it
will pending in surface dequeubuffer() with hold of EGL lock, and will
block HeifWriter thread executing, the buffer will be returned after
HeifWriter handled, In this case HeifWriter waiting for the EGL lock,
and drawframe thread wait for buffer with EGL lock hold, so deadlock
produced.

In case this is not the first time run of make_current(), allocate
buffer can be postponed, and allocate buffer in a context without
hold of EGL lock.

Signed-off-by: Yang, Dong <dong.yang@intel.com>