### PR TITLE
INTERNEL: Check height & width before create resource

### DIFF
--- a/src/gallium/winsys/virgl/drm/virgl_drm_winsys.c
+++ b/src/gallium/winsys/virgl/drm/virgl_drm_winsys.c
@@ -181,6 +181,11 @@ virgl_drm_winsys_resource_create(struct virgl_winsys *qws,
    createcmd.stride = stride;
    createcmd.size = size;
 
+   if ((createcmd.height == 0) || (createcmd.width == 0)) {
+      FREE(res);
+      return NULL;
+   }
+
    ret = drmIoctl(qdws->fd, DRM_IOCTL_VIRTGPU_RESOURCE_CREATE, &createcmd);
    if (ret != 0) {
       FREE(res);


### PR DESCRIPTION
We should confirm height & width valid before call
create_resource, otherwise virglrenderer driver will
run into error.

Tracked-On: OAM-97927
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>