### PR TITLE
INTERNEL: Do not cache depth and stencil buffers

### DIFF
--- a/src/gallium/winsys/virgl/drm/virgl_drm_winsys.c
+++ b/src/gallium/winsys/virgl/drm/virgl_drm_winsys.c
@@ -62,8 +62,12 @@ static inline boolean can_cache_resource(uint32_t bind)
           bind == VIRGL_BIND_INDEX_BUFFER ||
           bind == VIRGL_BIND_VERTEX_BUFFER ||
           bind == VIRGL_BIND_CUSTOM ||
+#if defined(ANDROID)
+          bind == VIRGL_BIND_STAGING;
+#else
           bind == VIRGL_BIND_STAGING ||
           bind == VIRGL_BIND_DEPTH_STENCIL;
+#endif
 }
 
 static void virgl_hw_res_destroy(struct virgl_drm_winsys *qdws,


### PR DESCRIPTION
On Android, there will be garbage when screen rotation
during video playback.
This is to revert d245d7b6b8bb

Signed-off-by: Chenglei Ren <chenglei.ren@intel.com>
Tracked-On: OAM-99620