### PR TITLE
[INTERNAL] Pointing flex and bison to prebuilts

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -45,7 +45,8 @@ MESA_COMMON_MK := $(MESA_TOP)/Android.common.mk
 MESA_PYTHON2 := PYTHONPATH=$(PWD)/development/python-packages:$$PYTHONPATH python
 MESA_PYTHON3 := PYTHONPATH=$(PWD)/development/python-packages:$$PYTHONPATH python3
 ifeq ($(filter 5 6 7 8 9 10, $(MESA_ANDROID_MAJOR_VERSION)),)
-MESA_LEX     := M4=$(M4) $(LEX)
+MESA_LEX     := M4=$(PWD)/prebuilts/build-tools/linux-x86/bin/m4 $(PWD)/prebuilts/build-tools/linux-x86/bin/flex
+MESA_BISON     := M4=$(PWD)/prebuilts/build-tools/linux-x86/bin/m4 $(PWD)/prebuilts/build-tools/linux-x86/bin/bison
 else
 MESA_LEX     := $(LEX)
 endif

--- a/src/compiler/Android.glsl.gen.mk
+++ b/src/compiler/Android.glsl.gen.mk
@@ -59,7 +59,7 @@ endef
 define glsl_local-y-to-c-and-h
 	@mkdir -p $(dir $@)
 	@echo "Mesa Yacc: $(PRIVATE_MODULE) <= $<"
-	$(hide) $(YACC) -o $@ -p "glcpp_parser_" $<
+	$(hide) $(MESA_BISON) -d -o $@ -p "glcpp_parser_" $<
 endef
 
 YACC_HEADER_SUFFIX := .hpp
@@ -67,7 +67,7 @@ YACC_HEADER_SUFFIX := .hpp
 define local-yy-to-cpp-and-h
 	@mkdir -p $(dir $@)
 	@echo "Mesa Yacc: $(PRIVATE_MODULE) <= $<"
-	$(hide) $(YACC) -p "_mesa_glsl_" -o $@ $<
+	$(hide) $(MESA_BISON) -d -p "_mesa_glsl_" -o $@ $<
 	touch $(@:$1=$(YACC_HEADER_SUFFIX))
 	echo '#ifndef '$(@F:$1=_h) > $(@:$1=.h)
 	echo '#define '$(@F:$1=_h) >> $(@:$1=.h)

--- a/src/freedreno/Android.ir3.mk
+++ b/src/freedreno/Android.ir3.mk
@@ -91,12 +91,12 @@ $(intermediates)/ir3/ir3_nir_trig.c: $(ir3_nir_trig_deps)
 $(intermediates)/ir3/ir3_parser.c: $(ir3_parser_deps)
 	@mkdir -p $(dir $@)
 	@echo "Gen Header: $(PRIVATE_MODULE) <= $(notdir $(@))"
-	$(hide) $(BISON) $< --name-prefix=ir3_yy --output=$@
+	$(hide) $(MESA_BISON) $< --name-prefix=ir3_yy --output=$@
 
 $(intermediates)/ir3/ir3_parser.h: $(ir3_parser_deps)
 	@mkdir -p $(dir $@)
 	@echo "Gen Header: $(PRIVATE_MODULE) <= $(notdir $(@))"
-	$(hide) $(BISON) $< --name-prefix=ir3_yy --defines=$@
+	$(hide) $(MESA_BISON) $< --name-prefix=ir3_yy --defines=$@
 
 include $(MESA_COMMON_MK)
 include $(BUILD_STATIC_LIBRARY)

--- a/src/mesa/program/Android.mk
+++ b/src/mesa/program/Android.mk
@@ -29,7 +29,7 @@ endef
 define mesa_local-y-to-c-and-h
 	@mkdir -p $(dir $@)
 	@echo "Mesa Yacc: $(PRIVATE_MODULE) <= $<"
-	$(hide) $(YACC) -o $@ -p "_mesa_program_" $<
+	$(hide) $(MESA_BISON) -d -o $@ -p "_mesa_program_" $<
 endef
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
This patch points the m4, flex and bison to the prebuilts
binary.

Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>