### PR TITLE
Fix 10bit video display issue

### DIFF
--- a/src/egl/drivers/dri2/platform_android.c
+++ b/src/egl/drivers/dri2/platform_android.c
@@ -387,7 +387,7 @@ droid_create_image_from_prime_fds_yuv(_EGLDisplay *disp,
     * the single-fd case cannot happen.  So handle eithe single
     * fd or fd-per-plane case:
     */
-   int num_planes = (ycbcr.chroma_step == 2) ? 2 : 3;
+   int num_planes = (ycbcr.chroma_step == 2 || ycbcr.chroma_step == 4) ? 2 : 3;
    if (num_fds == 1) {
       fds[2] = fds[1] = fds[0];
    } else {


### PR DESCRIPTION
This change is to correct plane number for
P010 format. The expected plane number should
be 2, but we got 3, which caused no image created
for P010 display.

Tracked-On: OAM-100284
Signed-off-by: Chen, Tianmi <tianmi.chen@intel.com>