### PR TITLE
Add fd protection in mesa3d library

### DIFF
--- a/src/gallium/drivers/iris/iris_screen.c
+++ b/src/gallium/drivers/iris/iris_screen.c
@@ -625,7 +625,8 @@ iris_screen_destroy(struct iris_screen *screen)
    u_transfer_helper_destroy(screen->base.transfer_helper);
    iris_bufmgr_unref(screen->bufmgr);
    disk_cache_destroy(screen->disk_cache);
-   close(screen->winsys_fd);
+   // fd close is handled by owner module
+   //close(screen->winsys_fd);
    ralloc_free(screen);
 }
 


### PR DESCRIPTION
fd created needs protection to avoid being closed by other threads
fixed double close issue in iris_screen_destroy() function.

Tracked-On: OAM-102221
Signed-off-by: Basanagouda Koppad <basanagoudax.n.koppad@intel.com>