### PR TITLE
meson_options: Bump max value of platform-sdk-version to 33

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -455,7 +455,7 @@ option(
   'platform-sdk-version',
   type : 'integer',
   min : 25,
-  max : 31,
+  max : 33,
   value : 25,
   description : 'Android Platform SDK version. Default: Nougat version.'
 )


### PR DESCRIPTION
During building Android-13, the following error appears:
meson.build:21:0: ERROR: New value 33 is more than maximum value 31.

Tracked-On: OAM-103588
Signed-off-by: svenate <salini.venate@intel.com>