### PR TITLE
Iris: Fix to release BO immediately if not busy

### DIFF
--- a/src/gallium/drivers/iris/iris_bufmgr.c
+++ b/src/gallium/drivers/iris/iris_bufmgr.c
@@ -1354,6 +1354,8 @@ bo_free(struct iris_bo *bo)
    if (!bo->real.userptr && bo->real.map)
       bo_unmap(bo);
 
+   iris_bo_busy(bo);
+
    if (bo->idle) {
       bo_close(bo);
    } else {


### PR DESCRIPTION
Currently the iris driver is adding the buffer objects to zombie list without checking if it is busy or not. It checks for it after 1 second which adds delay to buffer release.

This fix checks if the bo is busy or not before adding it to zombie list.

Without this fix, the applications expecting immediate buffer release would fail.

The fix is identified while debugging below cts tests: 
android.graphics.cts.BitmapTest#testDrawingHardwareBitmapNotLeaking android.graphics.cts.BitmapTest#testHardwareBitmapNotLeaking

Tracked-On: OAM-105862
Signed-off-by: Sai Teja Pottumuttu <sai.teja.pottumuttu@intel.com>