### PR TITLE
Make gralloc4 mapper support YUV format

### DIFF
--- a/src/egl/drivers/dri2/platform_android.c
+++ b/src/egl/drivers/dri2/platform_android.c
@@ -53,11 +53,6 @@
 
 #define ALIGN(val, align)	(((val) + (align) - 1) & ~((align) - 1))
 
-enum chroma_order {
-   YCbCr,
-   YCrCb,
-};
-
 struct droid_yuv_format {
    /* Lookup keys */
    int native; /* HAL_PIXEL_FORMAT_ */
@@ -97,7 +92,7 @@ static const struct droid_yuv_format droid_yuv_formats[] = {
    { HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED, YCrCb, 1, DRM_FORMAT_XYUV8888 },
 };
 
-static int
+int
 get_fourcc_yuv(int native, enum chroma_order chroma_order, int chroma_step)
 {
    for (int i = 0; i < ARRAY_SIZE(droid_yuv_formats); ++i)
@@ -109,7 +104,7 @@ get_fourcc_yuv(int native, enum chroma_order chroma_order, int chroma_step)
    return -1;
 }
 
-static bool
+bool
 is_yuv(int native)
 {
    for (int i = 0; i < ARRAY_SIZE(droid_yuv_formats); ++i)

--- a/src/egl/drivers/dri2/platform_android.h
+++ b/src/egl/drivers/dri2/platform_android.h
@@ -136,10 +136,20 @@ struct buffer_info {
    enum __DRIChromaSiting vertical_siting;
 };
 
+enum chroma_order {
+   YCbCr,
+   YCrCb,
+};
+
+
 #ifdef USE_IMAPPER4_METADATA_API
 #ifdef __cplusplus
 extern "C" {
 #endif
+extern bool
+is_yuv(int native);
+extern int
+get_fourcc_yuv(int native, enum chroma_order chroma_order, int chroma_step);
 extern int
 mapper_metadata_get_buffer_info(struct ANativeWindowBuffer *buf,
                                 struct buffer_info *out_buf_info);


### PR DESCRIPTION
Previously buffer info getting for YUV format by gralloc4 is not complete for egl image creation. Need calculate extra chroma information from layout info.

Tracked-On: OAM-106557