### PR TITLE
anv: Fix stride mismatch in mesa and minigbm

### DIFF
--- a/src/intel/vulkan/anv_android.c
+++ b/src/intel/vulkan/anv_android.c
@@ -536,6 +536,8 @@ anv_image_init_from_gralloc(struct anv_device *device,
                                                base_info->tiling);
    assert(format != ISL_FORMAT_UNSUPPORTED);
 
+   anv_info.stride = gralloc_info->stride * (isl_format_get_layout(format)->bpb / 8);
+
    result = anv_image_init(device, image, &anv_info);
    if (result != VK_SUCCESS)
       goto fail_init;

--- a/src/intel/vulkan/anv_image.c
+++ b/src/intel/vulkan/anv_image.c
@@ -1365,7 +1365,7 @@ anv_image_init(struct anv_device *device, struct anv_image *image,
                                            mod_explicit_info, isl_tiling_flags,
                                            create_info->isl_extra_usage_flags);
    } else {
-      r = add_all_surfaces_implicit_layout(device, image, fmt_list, 0,
+      r = add_all_surfaces_implicit_layout(device, image, fmt_list, create_info->stride,
                                            isl_tiling_flags,
                                            create_info->isl_extra_usage_flags);
    }

--- a/src/intel/vulkan/anv_private.h
+++ b/src/intel/vulkan/anv_private.h
@@ -3931,6 +3931,8 @@ struct anv_image_create_info {
 
    /** These flags will be added to any derived from VkImageCreateInfo. */
    isl_surf_usage_flags_t isl_extra_usage_flags;
+
+   uint32_t stride;
 };
 
 VkResult anv_image_init(struct anv_device *device, struct anv_image *image,


### PR DESCRIPTION
It is observed that in display resolutions where width is not equal to stride, vulkan rendering is being distorted. This is happening due to a stride calculation mismatch between minigbm and mesa.

This fix makes sure that the stride calculated in minigbm is passed to anv and isl.

The fix resolves the following two android CTS issues android.graphics.cts.VulkanPreTransformTest#testVulkanPreTransformNotSetToMatchCurrentTransform android.graphics.cts.VulkanPreTransformTest#testVulkanPreTransformSetToMatchCurrentTransform

Tracked-On: OAM-106986
Signed-off-by: Sai Teja Pottumuttu <sai.teja.pottumuttu@intel.com>