### PR TITLE
Revert "INTERNAL: Iris: Fix to release BO immediately if not busy"

### DIFF
--- a/src/gallium/drivers/iris/iris_bufmgr.c
+++ b/src/gallium/drivers/iris/iris_bufmgr.c
@@ -1394,8 +1394,6 @@ bo_free(struct iris_bo *bo)
    if (!bo->real.userptr && bo->real.map)
       bo_unmap(bo);
 
-   iris_bo_busy(bo);
-
    if (bo->idle) {
       bo_close(bo);
    } else {


### PR DESCRIPTION
Revert "INTERNAL: Iris: Fix to release BO immediately if not busy"
This reverts commit https://github.com/projectceladon/external-mesa/commit/3d6c7fb87ae85068311083d52832ddc0b4e7b59e.

Tracked-On: OAM-108904
Signed-off-by: Jia, Lin A <lin.a.jia@intel.com>