### PR TITLE
Dump specified frame batch buffer

### DIFF
--- a/src/intel/common/meson.build
+++ b/src/intel/common/meson.build
@@ -54,12 +54,12 @@ files_batch_decoder = files(
 )
 
 batch_decoder_dependencies = []
-if with_platform_android
-  files_libintel_common += 'intel_batch_decoder_stub.c'
-else
+# if with_platform_android
+#   files_libintel_common += 'intel_batch_decoder_stub.c'
+# else
   batch_decoder_dependencies += dep_expat
   files_libintel_common += files_batch_decoder
-endif
+# endif
 
 libintel_common = static_library(
   'intel_common',


### PR DESCRIPTION
Frame no is specified by env CAPTURE_FRAME_NO
On IVI,the buffer file path is /data/local/tmp/mesa3d_intel.
On Linux, the buffer file path is /tmp/mesa3d_intel

Usage:
INTEL_DEBUG=bat CAPTURE_FRAME_NO=3692 aicreplay xxx.trace