### PR TITLE
anv: Force disable KHR_present_wait on android platform

### DIFF
--- a/src/vulkan/wsi/wsi_common.c
+++ b/src/vulkan/wsi/wsi_common.c
@@ -1548,6 +1548,11 @@ wsi_GetDeviceGroupSurfacePresentModesKHR(VkDevice device,
 bool
 wsi_common_vk_instance_supports_present_wait(const struct vk_instance *instance)
 {
+   /* Force disable KHR_present_wait on android platform. */
+#if defined(ANDROID) && ANDROID_API_LEVEL >= 34
+   return false;
+#endif
+
    /* We can only expose KHR_present_wait and KHR_present_id
     * if we are guaranteed support on all potential VkSurfaceKHR objects. */
    if (instance->enabled_extensions.KHR_wayland_surface ||


### PR DESCRIPTION
KHR_present_wait is not supported well on android platform, it's already disabled in driver, but it's conditional. The logic to detect whether to enable this extension is not robust and causes this extension to be enabled in CTS test:
dEQP-VK.wsi.android.present_id_wait.*. So force disable it to fix this issue.

Tracked-On: OAM-118018