### PR TITLE
Add VK_EXT_device_memory_report support.

### DIFF
--- a/src/intel/vulkan/anv_device.c
+++ b/src/intel/vulkan/anv_device.c
@@ -333,6 +333,7 @@ get_device_extensions(const struct anv_physical_device *device,
       .EXT_depth_range_unrestricted          = device->info.ver >= 20,
       .EXT_depth_clip_enable                 = true,
       .EXT_descriptor_indexing               = true,
+      .EXT_device_memory_report              = true,
 #ifdef VK_USE_PLATFORM_DISPLAY_KHR
       .EXT_display_control                   = true,
 #endif


### PR DESCRIPTION
Vts checkVulkanDeviceMemoryReportSupport test requires that vulkan devices with API version >= 1.1 must support VK_EXT_device_memory_report. Add VK_EXT_device_memory_report in vk_device_extension_table to pass the test.

Tracked-On: OAM-118749