### PR TITLE
anv/android: enable emulated astc for 3Dmark app issue

### DIFF
--- a/src/intel/vulkan/layers/anv_android_layer.c
+++ b/src/intel/vulkan/layers/anv_android_layer.c
@@ -38,7 +38,8 @@ android_CreateImageView(VkDevice _device,
     * format.
     */
    if (fmt && fmt->layout == UTIL_FORMAT_LAYOUT_ASTC &&
-       device->info->verx10 >= 125) {
+       device->info->verx10 >= 125 &&
+       !(device->physical->has_astc_ldr || device->physical->emu_astc_ldr)){
       return vk_errorf(device, VK_ERROR_OUT_OF_HOST_MEMORY,
                        "ASTC format not supported (%s).", __func__);
    }


### PR DESCRIPTION
This layer was blocking Android emulated ASTC support as it did not take "emu_astc_ldr" into account.
this commit already promoted to upstream mesa:
https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/29415

Tracked-On: OAM-118516