### PR TITLE
[Android 12] Revert "INTERNAL: Revert 530ae32c:iris:Fix to release BO immediately …

### DIFF
--- a/src/gallium/drivers/iris/iris_bufmgr.c
+++ b/src/gallium/drivers/iris/iris_bufmgr.c
@@ -1514,7 +1514,7 @@ bo_free(struct iris_bo *bo)
    if (!bo->real.userptr && bo->real.map)
       bo_unmap(bo);
 
-   if (bo->idle) {
+   if (bo->idle || !iris_bo_busy(bo)) {
       bo_close(bo);
    } else {
       /* Defer closing the GEM BO and returning the VMA for reuse until the


### PR DESCRIPTION
…if not busy"

This reverts commit de912b61e0648d6435dddf220e48ed4856524a57. This can avoid CTS incorrectly report "memory leak" if release BO immediately

Tracked-On: OAM-122043