### PR TITLE
Refine the dGPU render

### DIFF
--- a/src/egl/drivers/dri2/platform_android.c
+++ b/src/egl/drivers/dri2/platform_android.c
@@ -1084,19 +1084,17 @@ droid_open_device(_EGLDisplay *disp, bool swrast)
       if (!(device->available_nodes & (1 << node_type)))
          goto next;
 
-      if (intel_is_dgpu_render()) {
-         assert (node_type == DRM_NODE_RENDER);
-         int render_node = atoi(device->nodes[node_type] + 16); // skip "/dev/dri/renderD" prefix
-         if (render_node == 128)
-            goto next;
-      }
-
       dri2_dpy->fd_render_gpu = loader_open_device(device->nodes[node_type]);
 
       if (dri2_dpy->fd_render_gpu < 0) {
          _eglLog(_EGL_WARNING, "%s() Failed to open DRM device %s", __func__,
                  device->nodes[node_type]);
          goto next;
+      }
+
+      if ((get_intel_node_num() > 1) && intel_is_dgpu_render() && !is_dgpu(dri2_dpy->fd_render_gpu)) {
+          close(dri2_dpy->fd_render_gpu);
+          goto next;
       }
 
       /* If a vendor is explicitly provided, we use only that.

--- a/src/intel/common/intel_check.c
+++ b/src/intel/common/intel_check.c
@@ -8,6 +8,9 @@
 #include <sys/syscall.h>
 #include <stdbool.h>
 #include <cutils/properties.h>
+#include "util/macros.h"
+#include "util/log.h"
+#include "drm-uapi/i915_drm.h"
 #include "intel_check.h"
 
 #ifndef BUF_SIZE
@@ -92,4 +95,66 @@ bool intel_lower_ctx_priority(void)
       }
    }
    return false;
+}
+
+bool has_local_mem(int fd)
+{
+   struct drm_i915_query_item item = {
+      .query_id = DRM_I915_QUERY_MEMORY_REGIONS,
+   };
+
+   struct drm_i915_query query = {
+      .num_items = 1, .items_ptr = (uintptr_t)&item,
+   };
+   if (drmIoctl(fd, DRM_IOCTL_I915_QUERY, &query)) {
+      mesa_loge("ioctl fail\n");
+      return false;
+   }
+   struct drm_i915_query_memory_regions *meminfo = calloc(1, item.length);
+   if (!meminfo) {
+      mesa_loge("memory fail\n");
+      return false;
+   }
+   item.data_ptr = (uintptr_t)meminfo;
+   if (drmIoctl(fd, DRM_IOCTL_I915_QUERY, &query) || item.length <= 0) {
+      free(meminfo);
+      mesa_loge("item.length <= 0\n");
+      return false;
+   }
+
+   uint64_t lmem_regions = 0;
+   for (uint32_t i = 0; i < meminfo->num_regions; i++) {
+      const struct drm_i915_memory_region_info *mem = &meminfo->regions[i];
+      if (mem->region.memory_class == I915_MEMORY_CLASS_DEVICE)
+         lmem_regions += 1;
+   }
+
+   free(meminfo);
+
+   return lmem_regions > 0;
+}
+
+bool is_dgpu(int fd)
+{
+   return has_local_mem(fd);
+}
+
+int get_intel_node_num(void)
+{
+   drmDevicePtr devices[8];
+   int num_devs;
+   num_devs = drmGetDevices2(0, devices, ARRAY_SIZE(devices));
+
+   int intel_node_num = 0;
+   for (int i = 0; i < num_devs; i++) {
+      if (!(devices[i]->available_nodes & (1 << DRM_NODE_RENDER)) ||
+         devices[i]->bustype != DRM_BUS_PCI ||
+         devices[i]->deviceinfo.pci->vendor_id != 0x8086) {
+         continue;
+      }
+      else {
+        ++intel_node_num;
+      }
+   }
+   return intel_node_num;
 }

--- a/src/intel/common/intel_check.h
+++ b/src/intel/common/intel_check.h
@@ -1,11 +1,15 @@
 #ifndef _CHECK_DGPU_H
 #define _CHECK_DGPU_H
 #include <stdbool.h>
+#include "util/libdrm.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
 bool intel_is_dgpu_render(void);
 bool intel_lower_ctx_priority(void);
+bool is_dgpu(int id);
+bool has_local_mem(int fd);
+int get_intel_node_num(void);
 #ifdef __cplusplus
 }
 #endif

--- a/src/intel/vulkan/anv_device.c
+++ b/src/intel/vulkan/anv_device.c
@@ -61,6 +61,7 @@
 #include "common/intel_aux_map.h"
 #include "common/intel_uuid.h"
 #include "common/i915/intel_gem.h"
+#include "common/intel_check.h"
 #include "perf/intel_perf.h"
 
 #include "i915/anv_device.h"
@@ -2147,10 +2148,6 @@ anv_physical_device_try_create(struct vk_instance *vk_instance,
    const char *primary_path = drm_device->nodes[DRM_NODE_PRIMARY];
    const char *path = drm_device->nodes[DRM_NODE_RENDER];
 
-   if (path != NULL && strstr(path, "renderD129") != NULL) {
-      return VK_ERROR_INCOMPATIBLE_DRIVER;
-   }
-
    VkResult result;
    int fd;
    int master_fd = -1;
@@ -2171,6 +2168,18 @@ anv_physical_device_try_create(struct vk_instance *vk_instance,
    if (!intel_get_device_info_from_fd(fd, &devinfo)) {
       result = vk_error(instance, VK_ERROR_INCOMPATIBLE_DRIVER);
       goto fail_fd;
+   }
+
+   if (get_intel_node_num() > 1) {
+      if (!is_dgpu(fd) && intel_is_dgpu_render()) {
+         result = VK_ERROR_INCOMPATIBLE_DRIVER;
+         goto fail_fd;
+      }
+
+      if (is_dgpu(fd) && !intel_is_dgpu_render()) {
+         result = VK_ERROR_INCOMPATIBLE_DRIVER;
+         goto fail_fd;
+      }
    }
 
    if (devinfo.ver == 20) {


### PR DESCRIPTION
Check the dGPU through whether has local memory.
Calculate the i915 render node number for better
compatibility.
The GLES open one available render node, vulkan
open all available render nodes.
Enalbe the vulkan dGPU render.

Tracked-On: OAM-122333