### PR TITLE
anv: Add idep_genxml to dependencies of grl_genX_libs

### DIFF
--- a/src/intel/vulkan/grl/meson.build
+++ b/src/intel/vulkan/grl/meson.build
@@ -158,7 +158,7 @@ foreach t : [['125', 'gfx125', 'dg2']]
     ],
     dependencies : [
       dep_valgrind, idep_nir_headers, idep_vulkan_util_headers, idep_vulkan_wsi_headers,
-      idep_vulkan_runtime_headers, idep_anv_headers,
+      idep_vulkan_runtime_headers, idep_anv_headers, idep_genxml,
     ],
     gnu_symbol_visibility : 'hidden',
   )


### PR DESCRIPTION
Fix race condition when building ANV:

    In file included from src/intel/vulkan/grl/grl_metakernel_build_primref.c:40:
    ../src/intel/common/mi_builder.h:28:10: fatal error: 'genxml/genX_bits.h' file not found
    #include "genxml/genX_bits.h"

This change is already included in commit
41b2ed65e2532fd3be9ee7b74c74401169e81acd (genxml: generate opencl packing headers) in the upstream.  Hence when updating mesa version, this change can be safely removed.