### PR TITLE
Backport upstream fix

### DIFF
--- a/src/gallium/frontends/dri/dri2.c
+++ b/src/gallium/frontends/dri/dri2.c
@@ -2385,7 +2385,7 @@ dri2_init_screen(struct dri_screen *screen)
       pscreen = pipe_loader_create_screen(screen->dev);
 
    if (!pscreen)
-       goto fail;
+       return NULL;
 
    dri_init_options(screen);
    screen->throttle = pscreen->get_param(pscreen, PIPE_CAP_THROTTLE);
@@ -2419,7 +2419,7 @@ dri2_init_screen(struct dri_screen *screen)
    return configs;
 
 fail:
-   dri_release_screen(screen);
+   pipe_loader_release(&screen->dev, 1);
 
    return NULL;
 }

--- a/src/gallium/frontends/dri/drisw.c
+++ b/src/gallium/frontends/dri/drisw.c
@@ -546,6 +546,8 @@ drisw_init_screen(struct dri_screen *screen)
    struct pipe_screen *pscreen = NULL;
    const struct drisw_loader_funcs *lf = &drisw_lf;
 
+   (void) mtx_init(&screen->opencl_func_mutex, mtx_plain);
+
    screen->swrast_no_present = debug_get_option_swrast_no_present();
 
    if (loader->base.version >= 4) {

--- a/src/gallium/frontends/dri/drisw.c
+++ b/src/gallium/frontends/dri/drisw.c
@@ -565,7 +565,7 @@ drisw_init_screen(struct dri_screen *screen)
       pscreen = pipe_loader_create_screen(screen->dev);
 
    if (!pscreen)
-      goto fail;
+      return NULL;
 
    dri_init_options(screen);
    configs = dri_init_screen(screen, pscreen);
@@ -593,7 +593,7 @@ drisw_init_screen(struct dri_screen *screen)
 
    return configs;
 fail:
-   dri_release_screen(screen);
+   pipe_loader_release(&screen->dev, 1);
    return NULL;
 }
 

--- a/src/gallium/frontends/dri/kopper.c
+++ b/src/gallium/frontends/dri/kopper.c
@@ -134,7 +134,7 @@ kopper_init_screen(struct dri_screen *screen)
       pscreen = pipe_loader_create_screen(screen->dev);
 
    if (!pscreen)
-      goto fail;
+      return NULL;
 
    dri_init_options(screen);
    screen->unwrapped_screen = trace_screen_unwrap(pscreen);
@@ -167,7 +167,7 @@ kopper_init_screen(struct dri_screen *screen)
 
    return configs;
 fail:
-   dri_release_screen(screen);
+   pipe_loader_release(&screen->dev, 1);
    return NULL;
 }
 

--- a/src/gallium/frontends/dri/kopper.c
+++ b/src/gallium/frontends/dri/kopper.c
@@ -115,6 +115,8 @@ kopper_init_screen(struct dri_screen *screen)
    const __DRIconfig **configs;
    struct pipe_screen *pscreen = NULL;
 
+   (void) mtx_init(&screen->opencl_func_mutex, mtx_plain);
+
    if (!screen->kopper_loader) {
       fprintf(stderr, "mesa: Kopper interface not found!\n"
                       "      Ensure the versions of %s built with this version of Zink are\n"


### PR DESCRIPTION
Without this patch when dri driver fails to load, the process will crash due to double releasing.

Detail: `dri_release_screen()` will be called twice when `dri2_init_screen()` fails in `driCretateNewScreen2()`.