### PR TITLE
anv: explicitly disable BT pool allocations at device init

### DIFF
--- a/src/intel/vulkan/genX_init_state.c
+++ b/src/intel/vulkan/genX_init_state.c
@@ -305,6 +305,18 @@ init_common_queue_state(struct anv_queue *queue, struct anv_batch *batch)
       sba.L1CacheControl = L1CC_WB;
 #endif
    }
+
+   /* Disable the POOL_ALLOC mechanism in HW. We found that this state can get
+    * corrupted (likely due to leaking from another context), the default
+    * value should be disabled. It doesn't cost anything to set it once at
+    * device initialization.
+    */
+#if GFX_VER >= 11 && GFX_VERx10 < 125
+   anv_batch_emit(batch, GENX(3DSTATE_BINDING_TABLE_POOL_ALLOC), btpa) {
+      btpa.MOCS = mocs;
+      btpa.BindingTablePoolEnable = false;
+   }
+#endif
 #endif
 
 #if GFX_VERx10 >= 125


### PR DESCRIPTION
Ported from upstream:
https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30841?commit_id=1f9c40a8d1b2ec3702862371af3a934e9a0c9cda

The default state doesn't seem well defined (or kernel driver bug maybe?). Let's just set it to disabled on platforms where we're not using it.

Signed-off-by: Lionel Landwerlin <lionel.g.landwerlin@intel.com>
Cc: mesa-stable
Found-by: Chuansheng Liu <chuansheng.liu@intel.com>
Reviewed-by: Tapani Pälli <tapani.palli@intel.com>
Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30841>

Tracked-On: OAM-124615