### PR TITLE
Enable Xe kernel mode driver support

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -687,6 +687,6 @@ option(
 option (
   'intel-xe-kmd',
   type : 'feature',
-  value : 'disabled',
+  value : 'enabled',
   description: 'Enable Intel Xe KMD support.'
 )


### PR DESCRIPTION
Tests done:
- Android boot in GVT-d mode with xe driver enabled

Tracked-On: OAM-124802