### PR TITLE
anv: Increase surface state pool range from 5G~7G to 5G~8G to avoid chimoHMI OOM

### DIFF
--- a/src/intel/vulkan/anv_va.c
+++ b/src/intel/vulkan/anv_va.c
@@ -115,7 +115,7 @@ anv_physical_device_init_va_ranges(struct anv_physical_device *device)
    va_at(&device->va.scratch_surface_state_pool,
          device->va.internal_surface_state_pool.addr,
          8 * _1Mb);
-   address = va_add(&device->va.bindless_surface_state_pool, address, 2 * _1Gb);
+   address = va_add(&device->va.bindless_surface_state_pool, address, 3 * _1Gb);
 
 
    /* PRMs & simulation disagrees on the actual size of this heap. Take the


### PR DESCRIPTION
Each descriptor pool is backed with a BO, in Chimo HMI, 1000+ descriptor pools are allocated,
which means 1000+ BOs are allocated, each BO with 2MB alignment (required by current prelim kernel),
causing 2GB pool is used up(5G ~ 7G). Increasing surface pool range from (5G ~ 7G) to (5G ~ 8G)
can avoid this issue in most cases.
    
This fix only works if gfx >= 125, because in this case SurfaceStateBaseAddress is
4G(internal_surface_state_pool.addr), so for the increased range(7G ~ 8G), offset from
SurfaceStateBaseAddress is still within 4GB. If gfx < 125, SurfaceStateBaseAddress is 3G
(binding_table_pool.addr), for range 7G~8G, offset from SurfaceStateBaseAddress will exceed 4GB limit.
    
This fix can be removed if future prelim kernel doesn't require 2MB alignment.