### PR TITLE
[WA for ChimoHMI] anv: Use 64KB alignment instead of 2MB alignment

### DIFF
--- a/src/intel/vulkan/anv_allocator.c
+++ b/src/intel/vulkan/anv_allocator.c
@@ -1388,6 +1388,10 @@ anv_bo_vma_alloc_or_close(struct anv_device *device,
 
    uint32_t align = device->physical->info.mem_alignment;
 
+   if (driQueryOptionb(&device->physical->instance->dri_options, "vk_descriptor_pool_64k_alignment") &&
+       alloc_flags & (ANV_BO_ALLOC_DESCRIPTOR_POOL | ANV_BO_ALLOC_SAMPLER_POOL))
+      align = 64 * 1024;
+
    /* If it's big enough to store a tiled resource, we need 64K alignment */
    if (bo->size >= 64 * 1024)
       align = MAX2(64 * 1024, align);

--- a/src/intel/vulkan/anv_device.c
+++ b/src/intel/vulkan/anv_device.c
@@ -109,6 +109,7 @@ static const driOptionDescription anv_dri_options[] = {
 #else
       DRI_CONF_VK_REQUIRE_ASTC(false)
 #endif
+      DRI_CONF_VK_DESCRIPTOR_POOL_64K_ALIGNMENT(false)
    DRI_CONF_SECTION_END
 
    DRI_CONF_SECTION_QUALITY

--- a/src/util/00-mesa-defaults.conf
+++ b/src/util/00-mesa-defaults.conf
@@ -1235,6 +1235,18 @@ TODO: document the other workarounds.
        <application name="Android CTS" executable="com.drawelements.deqp:testercore">
             <option name="vk_require_astc" value="false" />
         </application>
+       <application name="Chimo HMIMain" executable="com.intel.chimoHMIMain">
+            <option name="vk_descriptor_pool_64k_alignment" value="true" />
+       </application>
+       <application name="Chimo HMISecond" executable="com.intel.chimoHMISecond">
+            <option name="vk_descriptor_pool_64k_alignment" value="true" />
+       </application>
+       <application name="Chimo HMIDashboard" executable="com.intel.chimoHMIDashboard">
+            <option name="vk_descriptor_pool_64k_alignment" value="true" />
+       </application>
+       <application name="Chimo HMILong" executable="com.intel.chimoHMILong">
+            <option name="vk_descriptor_pool_64k_alignment" value="true" />
+       </application>
 
         <!-- Disable FCV optimization for Unreal Engine 5.1 workloads. -->
         <engine engine_name_match="UnrealEngine5.1">

--- a/src/util/driconf.h
+++ b/src/util/driconf.h
@@ -336,6 +336,10 @@
    DRI_CONF_OPT_B(vk_require_astc, def, \
                   "Implement emulated ASTC on HW that does not support it")
 
+#define DRI_CONF_VK_DESCRIPTOR_POOL_64K_ALIGNMENT(def) \
+   DRI_CONF_OPT_B(vk_descriptor_pool_64k_alignment, def, \
+                  "Force use 64k alignment when allocate BO for descriptor pool")
+
 /**
  * \brief Image quality-related options
  */


### PR DESCRIPTION
Chimo app allocate descriptor pool so frequently, with 2MB alignment the 2Gb descriptor pool heap vm address space is used up quickly.

This workaournd can be removed if future prelim kernel doesn't require 2MB alignment.

Tracked-On: OAM-124718