### PR TITLE
Alignment of Mesa in AAOS and SOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -205,6 +205,7 @@ with_gallium_kmsro = system_has_kms_drm and [
   with_gallium_panfrost,
   with_gallium_v3d,
   with_gallium_vc4,
+  with_gallium_iris,
 ].contains(true)
 
 _vulkan_drivers = get_option('vulkan-drivers')

--- a/src/gallium/auxiliary/pipe-loader/meson.build
+++ b/src/gallium/auxiliary/pipe-loader/meson.build
@@ -56,6 +56,9 @@ endif
 if with_gallium_asahi
   renderonly_drivers_c_args += '-DGALLIUM_ASAHI'
 endif
+if with_gallium_iris
+  renderonly_drivers_c_args += '-DGALLIUM_IRIS'
+endif
 
 libpipe_loader_static = static_library(
   'pipe_loader_static',

--- a/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
+++ b/src/gallium/auxiliary/pipe-loader/pipe_loader_drm.c
@@ -296,6 +296,9 @@ pipe_loader_get_compatible_render_capable_device_fd(int kms_only_fd)
 #if defined GALLIUM_VC4
       "vc4",
 #endif
+#if defined GALLIUM_IRIS
+      "i915",
+#endif
    };
 
    if (!pipe_loader_drm_probe_fd(&dev, kms_only_fd, false))
@@ -303,10 +306,12 @@ pipe_loader_get_compatible_render_capable_device_fd(int kms_only_fd)
    is_platform_device = (dev->type == PIPE_LOADER_DEVICE_PLATFORM);
    pipe_loader_release(&dev, 1);
 
+#ifndef GALLIUM_IRIS
    /* For display-only devices that are not on the platform bus, we can't assume
     * that any of the rendering devices are compatible. */
    if (!is_platform_device)
       return -1;
+#endif
 
    /* For platform display-only devices, we try to find a render-capable device
     * on the platform bus and that should be compatible with the display-only

--- a/src/gallium/auxiliary/target-helpers/drm_helper.h
+++ b/src/gallium/auxiliary/target-helpers/drm_helper.h
@@ -68,6 +68,7 @@ const struct drm_driver_descriptor descriptor_name = {         \
 #undef GALLIUM_PANFROST
 #undef GALLIUM_LIMA
 #undef GALLIUM_ASAHI
+#undef GALLIUM_IRIS
 #endif
 
 #ifdef GALLIUM_I915
@@ -453,6 +454,9 @@ const driOptionDescription kmsro_driconf[] = {
 #endif
 #ifdef GALLIUM_FREEDRENO
       #include "freedreno/driinfo_freedreno.h"
+#endif
+#ifdef GALLIUM_IRIS
+      #include "iris/driinfo_iris.h"
 #endif
 };
 DRM_DRIVER_DESCRIPTOR(kmsro, kmsro_driconf, ARRAY_SIZE(kmsro_driconf))

--- a/src/gallium/drivers/iris/iris_resource.c
+++ b/src/gallium/drivers/iris/iris_resource.c
@@ -1176,11 +1176,14 @@ iris_resource_create_for_image(struct pipe_screen *pscreen,
 {
    struct iris_screen *screen = (struct iris_screen *)pscreen;
    const struct intel_device_info *devinfo = screen->devinfo;
+   struct pipe_resource *pres;
 
    if (screen->ro &&
        (templ->bind & (PIPE_BIND_DISPLAY_TARGET |
                        PIPE_BIND_SCANOUT | PIPE_BIND_SHARED))) {
-      return iris_resource_create_renderonly(pscreen, templ);
+      pres = iris_resource_create_renderonly(pscreen, templ);
+      if (pres)
+        return pres;
    }
 
    struct iris_resource *res = iris_alloc_resource(pscreen, templ);
@@ -1954,8 +1957,7 @@ iris_resource_get_handle(struct pipe_screen *pscreen,
    case WINSYS_HANDLE_TYPE_KMS: {
       iris_gem_set_tiling(bo, &res->surf);
 
-      if (screen->ro) {
-         assert(res->scanout);
+      if (screen->ro && res->scanout) {
          return renderonly_get_handle(res->scanout, whandle);
       }
       /* Because we share the same drm file across multiple iris_screen, when

--- a/src/gallium/drivers/iris/iris_resource.h
+++ b/src/gallium/drivers/iris/iris_resource.h
@@ -55,6 +55,7 @@ struct iris_format_info {
 struct iris_resource {
    struct threaded_resource base;
    enum pipe_format internal_format;
+   struct renderonly_scanout *scanout;
 
    /**
     * The ISL surface layout information for this resource.

--- a/src/gallium/drivers/iris/iris_screen.c
+++ b/src/gallium/drivers/iris/iris_screen.c
@@ -59,6 +59,7 @@
 #include "intel/common/intel_l3_config.h"
 #include "intel/common/intel_uuid.h"
 #include "iris_monitor.h"
+#include "renderonly/renderonly.h"
 
 #define genX_call(devinfo, func, ...)             \
    switch ((devinfo)->verx10) {                   \
@@ -677,6 +678,7 @@ iris_screen_destroy(struct iris_screen *screen)
    iris_bufmgr_unref(screen->bufmgr);
    disk_cache_destroy(screen->disk_cache);
    close(screen->winsys_fd);
+   free(screen->ro);
    ralloc_free(screen);
 }
 

--- a/src/gallium/drivers/iris/iris_screen.h
+++ b/src/gallium/drivers/iris/iris_screen.h
@@ -161,6 +161,7 @@ struct iris_address {
 
 struct iris_screen {
    struct pipe_screen base;
+   struct renderonly *ro;
 
    uint32_t refcount;
 

--- a/src/gallium/winsys/iris/drm/iris_drm_public.h
+++ b/src/gallium/winsys/iris/drm/iris_drm_public.h
@@ -26,8 +26,13 @@
 
 struct pipe_screen;
 struct pipe_screen_config;
+struct renderonly;
 
 struct pipe_screen *
 iris_drm_screen_create(int drm_fd, const struct pipe_screen_config *config);
+
+struct pipe_screen *
+iris_screen_create_renderonly(struct renderonly *ro,
+                              const struct pipe_screen_config *config);
 
 #endif /* IRIS_DRM_PUBLIC_H */

--- a/src/gallium/winsys/iris/drm/iris_drm_public.h
+++ b/src/gallium/winsys/iris/drm/iris_drm_public.h
@@ -32,7 +32,7 @@ struct pipe_screen *
 iris_drm_screen_create(int drm_fd, const struct pipe_screen_config *config);
 
 struct pipe_screen *
-iris_screen_create_renderonly(struct renderonly *ro,
+iris_screen_create_renderonly(int fd, struct renderonly *ro,
                               const struct pipe_screen_config *config);
 
 #endif /* IRIS_DRM_PUBLIC_H */

--- a/src/gallium/winsys/iris/drm/iris_drm_winsys.c
+++ b/src/gallium/winsys/iris/drm/iris_drm_winsys.c
@@ -40,12 +40,12 @@ iris_drm_screen_create(int fd, const struct pipe_screen_config *config)
 }
 
 struct pipe_screen *
-iris_screen_create_renderonly(struct renderonly *ro,
+iris_screen_create_renderonly(int fd, struct renderonly *ro,
                               const struct pipe_screen_config *config)
 {
    struct iris_screen *pscreen;
 
-   pscreen = (struct iris_screen *)iris_screen_create(os_dupfd_cloexec(ro->gpu_fd), config);
+   pscreen = (struct iris_screen *)iris_screen_create(os_dupfd_cloexec(fd), config);
    if (!pscreen)
       return NULL;
 

--- a/src/gallium/winsys/iris/drm/iris_drm_winsys.c
+++ b/src/gallium/winsys/iris/drm/iris_drm_winsys.c
@@ -26,11 +26,31 @@
 
 #include "util/os_file.h"
 
+#include "renderonly/renderonly.h"
+#include "kmsro/drm/kmsro_drm_public.h"
 #include "iris_drm_public.h"
+#include "iris/iris_screen.h"
+
 extern struct pipe_screen *iris_screen_create(int fd, const struct pipe_screen_config *config);
 
 struct pipe_screen *
 iris_drm_screen_create(int fd, const struct pipe_screen_config *config)
 {
    return iris_screen_create(fd, config);
+}
+
+struct pipe_screen *
+iris_screen_create_renderonly(struct renderonly *ro,
+                              const struct pipe_screen_config *config)
+{
+   struct iris_screen *pscreen;
+
+   pscreen = (struct iris_screen *)iris_screen_create(os_dupfd_cloexec(ro->gpu_fd), config);
+   if (!pscreen)
+      return NULL;
+
+   pscreen->ro = ro;
+   pscreen->winsys_fd = ro->kms_fd;
+
+   return &pscreen->base;
 }

--- a/src/gallium/winsys/iris/drm/meson.build
+++ b/src/gallium/winsys/iris/drm/meson.build
@@ -18,12 +18,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+iris_drm_winsys_c_args = []
+if with_gallium_kmsro
+  iris_drm_winsys_c_args += '-DGALLIUM_KMSRO'
+endif
+
 libiriswinsys = static_library(
   'iriswinsys',
   files('iris_drm_winsys.c'),
   include_directories : [
     inc_src, inc_include,
-    inc_gallium, inc_gallium_aux, inc_gallium_drivers,
+    inc_gallium, inc_gallium_aux, inc_gallium_drivers, inc_gallium_winsys, inc_intel
   ],
+  c_args : [iris_drm_winsys_c_args],
   gnu_symbol_visibility : 'hidden',
 )

--- a/src/gallium/winsys/iris/drm/meson.build
+++ b/src/gallium/winsys/iris/drm/meson.build
@@ -28,8 +28,9 @@ libiriswinsys = static_library(
   files('iris_drm_winsys.c'),
   include_directories : [
     inc_src, inc_include,
-    inc_gallium, inc_gallium_aux, inc_gallium_drivers, inc_gallium_winsys, inc_intel
+    inc_gallium, inc_gallium_aux, inc_gallium_drivers, inc_gallium_winsys, inc_intel,
   ],
   c_args : [iris_drm_winsys_c_args],
+  dependencies: [ idep_intel_dev ],
   gnu_symbol_visibility : 'hidden',
 )

--- a/src/gallium/winsys/kmsro/drm/kmsro_drm_winsys.c
+++ b/src/gallium/winsys/kmsro/drm/kmsro_drm_winsys.c
@@ -33,6 +33,7 @@
 #include "panfrost/drm/panfrost_drm_public.h"
 #include "lima/drm/lima_drm_public.h"
 #include "asahi/drm/asahi_drm_public.h"
+#include "iris/drm/iris_drm_public.h"
 #include "xf86drm.h"
 
 #include "pipe/p_screen.h"
@@ -119,6 +120,11 @@ struct pipe_screen *kmsro_drm_screen_create(int kms_fd,
        */
       ro->create_for_resource = renderonly_create_gpu_import_for_resource;
       screen = vc4_drm_screen_create_renderonly(ro->gpu_fd, ro, config);
+#endif
+   } else if (strcmp(render_dev_name, "i915") == 0) {
+#if defined(GALLIUM_IRIS)
+      ro->create_for_resource = renderonly_create_kms_dumb_buffer_for_resource,
+      screen = iris_screen_create_renderonly(ro->gpu_fd, ro, config);
 #endif
    }
 

--- a/src/gallium/winsys/kmsro/drm/kmsro_drm_winsys.c
+++ b/src/gallium/winsys/kmsro/drm/kmsro_drm_winsys.c
@@ -123,7 +123,7 @@ struct pipe_screen *kmsro_drm_screen_create(int kms_fd,
 #endif
    } else if (strcmp(render_dev_name, "i915") == 0) {
 #if defined(GALLIUM_IRIS)
-      ro->create_for_resource = renderonly_create_kms_dumb_buffer_for_resource,
+      ro->create_for_resource = renderonly_create_gpu_import_for_resource,
       screen = iris_screen_create_renderonly(ro->gpu_fd, ro, config);
 #endif
    }

--- a/src/loader/loader.c
+++ b/src/loader/loader.c
@@ -154,8 +154,8 @@ loader_open_render_node_platform_device(const char * const drivers[],
    for (i = 0; i < num_devices; i++) {
       device = devices[i];
 
-      if ((device->available_nodes & (1 << DRM_NODE_RENDER)) &&
-          (device->bustype == DRM_BUS_PLATFORM)) {
+      if ((device->available_nodes & (1 << DRM_NODE_RENDER)) /* &&
+          (device->bustype == DRM_BUS_PLATFORM) */) {
          drmVersionPtr version;
 
          fd = loader_open_device(device->nodes[DRM_NODE_RENDER]);


### PR DESCRIPTION
Now that ACRN SOS uses celadon Mesa, port patches for SOS Mesa to this repo. This will reduce maintenance effort.