### PR TITLE
Fix CtsGpuProfilingDataTest fail

### DIFF
--- a/android/Android.mk
+++ b/android/Android.mk
@@ -183,8 +183,8 @@ ifneq ($(strip $(BOARD_MESA3D_GALLIUM_DRIVERS)),)
 $(eval $(call mesa3d-lib,libgallium_dri,.so.0,dri,MESA3D_GALLIUM_DRI_BIN))
 # Module 'libglapi', produces '/vendor/lib{64}/libglapi.so'
 $(eval $(call mesa3d-lib,libglapi,.so.0,,MESA3D_LIBGLAPI_BIN))
-# Module 'libpps-producer', produces '/vendor/lib{64}/libpps-producer.so'
-$(eval $(call mesa3d-lib,libpps-producer,.so.0,,MESA3D_LIBPPS_PRODUCER))
+# Module 'libgpudataproducer', produces '/vendor/lib{64}/libgpudataproducer.so'
+$(eval $(call mesa3d-lib,libgpudataproducer,.so.0,,MESA3D_LIBPPS_PRODUCER))
 
 # Module 'libEGL_mesa', produces '/vendor/lib{64}/egl/libEGL_mesa.so'
 $(eval $(call mesa3d-lib,libEGL_mesa,.so.1,egl,MESA3D_LIBEGL_BIN))
@@ -206,10 +206,9 @@ endif
 #-------------------------------------------------------------------------------
 
 include $(CLEAR_VARS)
-LOCAL_SHARED_LIBRARIES := libpps-producer
 LOCAL_SRC_FILES := perfetto/pps-producer.cc
 LOCAL_VENDOR_MODULE := true
-LOCAL_MODULE := pps-producer
+LOCAL_MODULE := gpudataproducer
 LOCAL_CPP_EXTENSION := .cc
 LOCAL_MODULE_TAGS := optional
 include $(BUILD_EXECUTABLE)

--- a/android/mesa3d_cross.mk
+++ b/android/mesa3d_cross.mk
@@ -96,6 +96,7 @@ MESON_GEN_NINJA := \
 	-Dlmsensors=disabled                                                         \
 	-Dandroid-libbacktrace=disabled                                              \
 	-Dperfetto=true                                                              \
+	-Ddatasources=auto                                                           \
 	$(BOARD_MESA3D_MESON_ARGS)                                                   \
 
 MESON_BUILD := PATH=/usr/bin:/bin:/sbin:$$PATH ninja -C $(MESON_OUT_DIR)/build

--- a/android/perfetto/pps-producer.cc
+++ b/android/perfetto/pps-producer.cc
@@ -1,5 +1,30 @@
-extern int pps_main(int argc, const char **argv);
+#include <cstdio>
+#include <dlfcn.h>
+
+typedef void (*pps_main_fn_t)(int, const char **);
+
+#define PPS_LIB "/vendor/lib64/libgpudataproducer.so"
 
 int main(int argc, const char **argv) {
-    return pps_main(argc, argv);
+  char *error;
+
+  void *handle = dlopen(PPS_LIB, RTLD_GLOBAL);
+  if ((error = dlerror()) != nullptr || handle == nullptr) {
+    fprintf(stdout, "Error loading lib: %s\n", error);
+    return -1;
+  }
+
+  pps_main_fn_t ppsFn = (pps_main_fn_t)dlsym(handle, "pps_main");
+  if (((error = dlerror()) != nullptr) || (ppsFn == nullptr)) {
+    fprintf(stdout, "Error looking for pps_main symbol: %s\n", error);
+    dlclose(handle);
+    return -1;
+  }
+
+  fprintf(stdout, "start call pps_main\n");
+  (*ppsFn)(argc, argv);
+  fprintf(stdout, "end call pps_main\n");
+
+  dlclose(handle);
+  return 0;
 }

--- a/src/intel/ds/intel_driver_ds.cc
+++ b/src/intel/ds/intel_driver_ds.cc
@@ -566,7 +566,12 @@ intel_driver_ds_init_once(void)
 #ifdef HAVE_PERFETTO
    util_perfetto_init();
    perfetto::DataSourceDescriptor dsd;
+#ifdef ANDROID
+   /* AGI requires this name */
+   dsd.set_name("gpu.renderstages");
+#else
    dsd.set_name("gpu.renderstages.intel");
+#endif
    IntelRenderpassDataSource::Register(dsd);
 #endif
 }

--- a/src/intel/ds/intel_pps_driver.cc
+++ b/src/intel/ds/intel_pps_driver.cc
@@ -19,6 +19,7 @@
 #include "drm-uapi/i915_drm.h"
 
 #include "common/intel_gem.h"
+#include <cutils/properties.h>
 #include "dev/intel_device_info.h"
 #include "perf/intel_perf.h"
 #include "perf/intel_perf_query.h"
@@ -85,7 +86,14 @@ bool IntelDriver::init_perfcnt()
 
    perf = std::make_unique<IntelPerf>(drm_device.fd);
 
-   const char *metric_set_name = getenv("INTEL_PERFETTO_METRIC_SET");
+   const char *metric_set_name = NULL;
+#ifdef ANDROID
+   char metric_set_buf[PROPERTY_VALUE_MAX] = "";
+   if (property_get("persist.vendor.intel.perfetto.metric_set", metric_set_buf, NULL) > 0)
+      metric_set_name = metric_set_buf;
+#else
+   metric_set_name = getenv("INTEL_PERFETTO_METRIC_SET");
+#endif
 
    struct intel_perf_query_info *default_query = nullptr;
    selected_query = nullptr;

--- a/src/tool/pps/cfg/gpu.cfg
+++ b/src/tool/pps/cfg/gpu.cfg
@@ -21,4 +21,13 @@ data_sources {
   }
 }
 
+data_sources {
+  config {
+    name: "gpu.counters"
+    gpu_counter_config {
+      counter_period_ns: 1000000000
+    }
+  }
+}
+
 duration_ms: 16000

--- a/src/tool/pps/cfg/intel.cfg
+++ b/src/tool/pps/cfg/intel.cfg
@@ -60,6 +60,21 @@ data_sources {
 
 data_sources {
   config {
+    name: "gpu.counters"
+    gpu_counter_config {
+      counter_period_ns: 100000
+    }
+  }
+}
+
+data_sources {
+  config {
+    name: "gpu.renderstages"
+  }
+}
+
+data_sources {
+  config {
     name: "track_event"
     track_event_config {
       enabled_categories: "mesa.default"

--- a/src/tool/pps/cfg/system.cfg
+++ b/src/tool/pps/cfg/system.cfg
@@ -41,6 +41,21 @@ data_sources {
 
 data_sources {
   config {
+    name: "gpu.counters"
+    gpu_counter_config {
+      counter_period_ns: 100000
+    }
+  }
+}
+
+data_sources {
+  config {
+    name: "gpu.renderstages"
+  }
+}
+
+data_sources {
+  config {
     name: "track_event"
     track_event_config {
       #enabled_tags: "slow"

--- a/src/tool/pps/pps_datasource.cc
+++ b/src/tool/pps/pps_datasource.cc
@@ -51,6 +51,8 @@ void GpuDataSource::OnSetup(const SetupArgs &args)
          }
 
          this->driver = driver;
+         // use first available driver, to avoid be covered by following failed driver.
+         break;
       }
    }
    if (driver == nullptr) {
@@ -324,7 +326,12 @@ void GpuDataSource::register_data_source(const std::string &_driver_name)
 {
    driver_name = _driver_name;
    static perfetto::DataSourceDescriptor dsd;
+#ifdef ANDROID
+   /* AGI requires this name */
+   dsd.set_name("gpu.counters");
+#else
    dsd.set_name("gpu.counters." + driver_name);
+#endif
 
    Driver * driver = nullptr;
    auto drm_devices = DrmDevice::create_all();
@@ -336,6 +343,8 @@ void GpuDataSource::register_data_source(const std::string &_driver_name)
       if ((driver != nullptr) && !driver->init_perfcnt()) {
          driver = nullptr;
       }
+      // use first available driver, to avoid be covered by following failed driver.
+      break;
    }
 
    if (driver != nullptr) {

--- a/src/tool/pps/pps_producer.cc
+++ b/src/tool/pps/pps_producer.cc
@@ -11,7 +11,7 @@
 
 #include "pps_datasource.h"
 
-int pps_main(int argc, const char **argv)
+extern "C" int pps_main(int argc, const char **argv)
 {
    using namespace pps;
 
@@ -34,4 +34,23 @@ int pps_main(int argc, const char **argv)
    }
 
    return EXIT_SUCCESS;
+}
+
+extern "C" void start()
+{
+   using namespace pps;
+
+   // Connects to the system tracing service
+   perfetto::TracingInitArgs args;
+   args.backends = perfetto::kSystemBackend;
+   perfetto::Tracing::Initialize(args);
+
+   GpuDataSource::register_data_source(Driver::default_driver_name());
+
+   while (true) {
+      GpuDataSource::wait_started();
+      GpuDataSource::Trace(GpuDataSource::trace_callback);
+   }
+
+   return;
 }


### PR DESCRIPTION
Rename the perfetto gpu data producer name from libpps-producer
 to libgpudataproducer to align with AGI/cts.

To pass the test, it also need following cmd:
1, echo "0" > /proc/sys/dev/i915/perf_stream_paranoid 2, setenforce 0
3, sysctl dev.i915.perf_stream_paranoid=0
   sysctl dev.i915_ag.perf_stream_paranoid=0
When in vm mode, at least 1 gpu needs to be passthoughed. SRIOV mode has no metrics info provided under dir:
  /sys/dev/char/%d:%d/device/drm

Tracked-On: OAM-128278