### PR TITLE
Fixed a VTS failure

### DIFF
--- a/src/intel/vulkan/anv_device.c
+++ b/src/intel/vulkan/anv_device.c
@@ -1326,7 +1326,7 @@ get_properties(const struct anv_physical_device *pdevice,
       .maxCullDistances                         = 8,
       .maxCombinedClipAndCullDistances          = 8,
       .discreteQueuePriorities                  = 2,
-      .pointSizeRange                           = { 0.125, 255.875 },
+      .pointSizeRange                           = (pdevice->info.verx10 >= 90) ? { 1.0, 2047.0 } : { 0.125, 255.875 },
       /* While SKL and up support much wider lines than we are setting here,
        * in practice we run into conformance issues if we go past this limit.
        * Since the Windows driver does the same, it's probably fair to assume


### PR DESCRIPTION
Update the value of pointSizeRange for Gen9+.

Tracked-On: OAM-130915