### PR TITLE
Fix cts DecodeGlAccuracyTest fail

### DIFF
--- a/src/util/u_gralloc/u_gralloc_imapper5_api.cpp
+++ b/src/util/u_gralloc/u_gralloc_imapper5_api.cpp
@@ -375,8 +375,6 @@ mapper_get_buffer_color_info(struct u_gralloc *gralloc,
       out->sample_range = __DRI_YUV_NARROW_RANGE;
       out->horizontal_siting = __DRI_YUV_CHROMA_SITING_0;
       out->vertical_siting = __DRI_YUV_CHROMA_SITING_0;
-
-      return 0;
    }
 
    auto importedHandle = import_buffer(gralloc, hnd->handle);


### PR DESCRIPTION
Previously the dataspace data for YUV is hardcoded. Since gralloc5 can retrieve the dataspace data now, we just set a default value and try to get real value from gralloc5.

Tracked-On: OAM-131274