### PR TITLE
Delete the dGPU render and system memory setting

### DIFF
--- a/src/intel/common/intel_check.c
+++ b/src/intel/common/intel_check.c
@@ -48,21 +48,12 @@ use_dgpu_render(char *target)
 {
    char dGPU_prop[BUF_SIZE];
    char vendor_buf[PROPERTY_VALUE_MAX];
-   snprintf(dGPU_prop, sizeof(dGPU_prop), "persist.vendor.intel.dGPUwSys%s", target);
+   snprintf(dGPU_prop, sizeof(dGPU_prop), "persist.vendor.intel.dGPUwLocal%s", target);
    if (property_get(dGPU_prop, vendor_buf, NULL) > 0) {
       if (vendor_buf[0] == '1') {
          return true;
       }
    }
-   char dGPU_prop1[BUF_SIZE];
-   char vendor_buf1[PROPERTY_VALUE_MAX];
-   snprintf(dGPU_prop1, sizeof(dGPU_prop1), "persist.vendor.intel.dGPUwLocal%s", target);
-   if (property_get(dGPU_prop1, vendor_buf1, NULL) > 0) {
-      if (vendor_buf1[0] == '1') {
-         return true;
-      }
-   }
-
    return false;
 }
 


### PR DESCRIPTION
The dgpu render and system memory doesn't reduce the usage of local memory. Delete it.

Tracked-On: OAM-131507