### PR TITLE
Fix PTL GPU hang issue when calling eglCreateImage

### DIFF
--- a/src/gallium/drivers/iris/iris_bufmgr.c
+++ b/src/gallium/drivers/iris/iris_bufmgr.c
@@ -1035,6 +1035,12 @@ alloc_bo_from_cache(struct iris_bufmgr *bufmgr,
       if (cur->real.capture != !!(flags & BO_ALLOC_CAPTURE))
          continue;
 
+      /* Make sure we don't recycle compressed vs non-compressed. */
+      if ((iris_heap_is_compressed(flags_to_heap(bufmgr, flags))) !=
+          iris_heap_is_compressed(cur->real.heap)) {
+            continue;
+      }
+
       /* If the last BO in the cache is busy, there are no idle BOs.  Bail,
        * either falling back to a non-matching memzone, or if that fails,
        * allocating a fresh buffer.

--- a/src/gallium/drivers/iris/iris_resource.c
+++ b/src/gallium/drivers/iris/iris_resource.c
@@ -1686,12 +1686,19 @@ iris_flush_resource(struct pipe_context *ctx, struct pipe_resource *resource)
    const struct isl_drm_modifier_info *mod = res->mod_info;
    bool newly_external = false;
 
+   /* We need to reallocate because original texture is compressed and we
+    * might end up doing a resolve.
+    */
+   bool need_reallocate =
+      res->aux.usage == ISL_AUX_USAGE_CCS_E &&
+      iris_bo_is_real(res->bo) && iris_heap_is_compressed(res->bo->real.heap);
+
    /* flush_resource() may be used to prepare an image for sharing externally
     * with other clients (e.g. via eglCreateImage).  To account for this, we
     * make sure to eliminate suballocation and any compression that a consumer
     * wouldn't know how to handle.
     */
-   if (!iris_bo_is_real(res->bo)) {
+   if (!iris_bo_is_real(res->bo) || need_reallocate) {
       assert(!(res->base.b.bind & PIPE_BIND_SHARED));
       iris_reallocate_resource_inplace(ice, res, PIPE_BIND_SHARED);
       assert(res->base.b.bind & PIPE_BIND_SHARED);


### PR DESCRIPTION
reallocating compressed bo on gfx20+
Upstream patch: https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/34499

