### PR TITLE
anv: Set Xe3 as supported

### DIFF
--- a/src/intel/vulkan/anv_physical_device.c
+++ b/src/intel/vulkan/anv_physical_device.c
@@ -2464,7 +2464,7 @@ anv_physical_device_try_create(struct vk_instance *vk_instance,
       /* If INTEL_FORCE_PROBE was used, then the user has opted-in for
        * unsupported device support. No need to print a warning message.
        */
-   } else if (devinfo.ver > 20) {
+   } else if (devinfo.ver > 30) {
       result = vk_errorf(instance, VK_ERROR_INCOMPATIBLE_DRIVER,
                          "Vulkan not yet supported on %s", devinfo.name);
       goto fail_fd;


### PR DESCRIPTION
Without this change, once we drop FORCE_PROBE from the PTL PCI IDs, we will get an error during Anvil driver init.

Tracked-On: OAM-132916
Ref: 16a835ed3d4 ("anv: Drop "not yet supported" warning for Xe2")