### PR TITLE
egl/android: Add 3 more video format for Android

### DIFF
--- a/src/util/u_gralloc/u_gralloc_internal.c
+++ b/src/util/u_gralloc/u_gralloc_internal.c
@@ -24,6 +24,15 @@ struct droid_yuv_format {
    int fourcc; /* DRM_FORMAT_ */
 };
 
+/* This enumeration can be deleted if Android defined it in
+ * system/core/include/system/graphics.h
+ */
+enum {
+   HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL = 0x100,
+   HAL_PIXEL_FORMAT_NV12 = 0x10F,
+   HAL_PIXEL_FORMAT_P010_INTEL = 0x110
+};
+
 /* The following table is used to look up a DRI image FourCC based
  * on native format and information contained in android_ycbcr struct. */
 static const struct droid_yuv_format droid_yuv_formats[] = {
@@ -32,6 +41,9 @@ static const struct droid_yuv_format droid_yuv_formats[] = {
    {HAL_PIXEL_FORMAT_YCbCr_420_888, YCbCr, 1, DRM_FORMAT_YUV420},
    {HAL_PIXEL_FORMAT_YCbCr_420_888, YCrCb, 1, DRM_FORMAT_YVU420},
    {HAL_PIXEL_FORMAT_YV12, YCrCb, 1, DRM_FORMAT_YVU420},
+   {HAL_PIXEL_FORMAT_NV12,            YCbCr, 2, DRM_FORMAT_NV12},
+   {HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL, YCbCr, 2, DRM_FORMAT_NV12},
+   {HAL_PIXEL_FORMAT_P010_INTEL,      YCbCr, 4, DRM_FORMAT_P010},
    /* HACK: See droid_create_image_from_prime_fds() and
     * https://issuetracker.google.com/32077885. */
    {HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED, YCbCr, 2, DRM_FORMAT_NV12},


### PR DESCRIPTION
This change is to help add NV12, NV12_Y_TILED_INTEL and P010 formats for Android.

TESTS: The following CtsViewTestCases cases could pass android.view.cts.PixelCopyTest#testVideoProducer
android.view.cts.SurfaceViewSyncTest#testVideoSurfaceViewCornerCoverage android.view.cts.SurfaceViewSyncTest#testVideoSurfaceViewTranslate android.view.cts.SurfaceViewSyncTest#testVideoSurfaceViewRotated android.view.cts.SurfaceViewSyncTest#testVideoSurfaceViewEdgeCoverage