### PR TITLE
Fix the Antutu11 GPU cases not supported issue.

### DIFF
--- a/src/intel/vulkan/anv_physical_device.c
+++ b/src/intel/vulkan/anv_physical_device.c
@@ -576,7 +576,7 @@ get_features(const struct anv_physical_device *pdevice,
       .accelerationStructureCaptureReplay = false, /* TODO */
       .accelerationStructureIndirectBuild = false, /* TODO */
       .accelerationStructureHostCommands = false,
-      .descriptorBindingAccelerationStructureUpdateAfterBind = rt_enabled,
+      .descriptorBindingAccelerationStructureUpdateAfterBind = false,
 
       /* VK_EXT_border_color_swizzle */
       .borderColorSwizzle = true,


### PR DESCRIPTION
Disable update acceleration structure descriptors after a set is bound.

Tracked-On: OAM-133989